### PR TITLE
Updating ext/noop logic in `get`

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,14 +173,18 @@ engines.get = function(ext) {
     return this.cache;
   }
 
-  ext = ext || this.noop;
   if (ext[0] !== '.') {
     ext = '.' + ext;
   }
 
-  var engine = this.cache[ext];
+  var noop = this.noop || '*';
+  if (noop[0] !== '.') {
+    noop = '.' + noop;
+  }
+
+  var engine = this.cache[ext] || this.cache[noop];
   if (!engine) {
-    engine = this.cache['*'];
+    engine = this.cache['.*'];
   }
   return engine;
 };


### PR DESCRIPTION
Since all engines are returned when `ext` is undefined, updating logic to try to get a noop engine if `ext` is defined, but not registered. Then returns the default `.*` engine if neither of those exist
