### PR TITLE
Compile fn

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "engine-lodash": "^0.7.1",
     "engines": "^0.4.0",
     "handlebars": "^3.0.2",
+    "lodash": "^3.10.0",
     "mocha": "^2.2.4",
     "should": "^6.0.1",
     "swig": "^1.4.2"

--- a/test/helpers.async.js
+++ b/test/helpers.async.js
@@ -32,7 +32,7 @@ describe('async helpers', function () {
     });
   });
 
-  it('should render content with handlebars.', function(done) {
+  it('should render content with multiple helpers in handlebars.', function(done) {
     engines.setEngine('hbs', consolidate.handlebars);
     var helpers = engines.helpers('hbs');
     helpers.addAsyncHelper('upper', function (str, options, callback) {

--- a/test/render.js
+++ b/test/render.js
@@ -19,35 +19,36 @@ describe('engines render', function () {
   });
 
   describe('.render()', function () {
-    it('should error when bad args are passed.', function(cb) {
+    it('should error when bad args are passed.', function(done) {
       engines.setEngine('hbs', consolidate.handlebars);
       var hbs = engines.getEngine('hbs');
 
       hbs.render(null, function (err, content) {
+        if (!err) return done(new Error('Expected an error'));
         err.message.should.equal('engine-cache `render` expects a string or function.');
-        cb();
+        done();
       });
     });
 
-    it('should render content with a cached engine: [handlebars].', function(cb) {
+    it('should render content with a cached engine: [handlebars].', function(done) {
       engines.setEngine('hbs', consolidate.handlebars);
       var hbs = engines.getEngine('hbs');
 
       hbs.render('{{name}}', {name: 'Jon Schlinkert'}, function (err, content) {
-        if (err) console.log(err);
+        if (err) return done(err);
         content.should.equal('Jon Schlinkert');
-        cb();
+        done();
       });
     });
 
-    it('should format engine errors.', function(cb) {
+    it('should format engine errors.', function(done) {
       engines.setEngine('tmpl', require('engine-lodash'));
       var tmpl = engines.getEngine('tmpl');
 
       tmpl.render('<%= foo %>', function (err, content) {
-        if (err) console.log(err);
+        if (!err) return done(new Error('Expected an error'));
         // content.should.equal('Jon Schlinkert');
-        cb();
+        done();
       });
     });
   });


### PR DESCRIPTION
Update `engine.compile` to always return a function that can be called directly and (sync or async) and the rendering (with async helper id resolution) will still be completed. This works with engines that contain their own `compile` function and engines that don't have a `compile` function.

The API works the same, but functions returned by `compile` can now take a callback to render async (and resolve async helper ids). Because of this, I'll bump to version `0.14.0`.